### PR TITLE
Remove markup normalizer

### DIFF
--- a/assets/nuxt/initNuxt.js
+++ b/assets/nuxt/initNuxt.js
@@ -11,18 +11,3 @@ lupus = Object.assign(lupus ? lupus : {}, {
     messages: { }
   }
 });
-
-/**
- * The goal of this part of the script is to remove the content injected from the frontproxy.
- * Removing the content restores the original DOM structure before the nuxt app is mounted,
- * so that the virtual dom tree matches the real one.
- */
-const breadcrumbs = document.querySelector('.breadcrumbs')
-
-if (window.lupusContentEl) {
-  window.lupusContentEl.innerHTML = '<!---->'
-}
-
-if (breadcrumbs) {
-  breadcrumbs.innerHTML = ''
-}


### PR DESCRIPTION
Remove markup normalizer from the front proxy.
This should never have been moved in here as it's critical this code stay in the nuxt app to guarantee this runs before the nuxt app code.