### PR TITLE
Limit metadata inserion to the first result

### DIFF
--- a/src/ResponseMerger/NuxtResponseMerger.php
+++ b/src/ResponseMerger/NuxtResponseMerger.php
@@ -73,7 +73,7 @@ class NuxtResponseMerger implements ResponseMergerInterface {
         }
       }
       if ($metatags_html != '') {
-        $page = preg_replace("/<head(.*?)>/", '<head$1>' . $metatags_html, $page);
+        $page = preg_replace("/<head(.*?)>/", '<head$1>' . $metatags_html, $page, 1);
       }
     }
 

--- a/src/ResponseMerger/NuxtResponseMerger.php
+++ b/src/ResponseMerger/NuxtResponseMerger.php
@@ -59,6 +59,8 @@ class NuxtResponseMerger implements ResponseMergerInterface {
       }
     }
     if ($metatags_html) {
+      // Limited to 1 to match only <head> and not <header> as well as not having duplicates,
+      // <head> will always be the first match as it precedes the document.
       $page = preg_replace("/<head(.*?)>/", '<head$1>' . $metatags_html, $page, 1);
     }
 

--- a/src/ResponseMerger/NuxtResponseMerger.php
+++ b/src/ResponseMerger/NuxtResponseMerger.php
@@ -59,7 +59,8 @@ class NuxtResponseMerger implements ResponseMergerInterface {
       }
     }
     if ($metatags_html) {
-      // Limited to 1 to match only <head> and not <header> as well as not having duplicates,
+      // Limited to 1 to match only <head> and not <header>
+      // and ensures that the metadata are inserted only once,
       // <head> will always be the first match as it precedes the document.
       $page = preg_replace("/<head(.*?)>/", '<head$1>' . $metatags_html, $page, 1);
     }


### PR DESCRIPTION
replacement was matching \<head> as well as \<header> limit should fix the issue since <head> will always come before anything related to the document.