### PR TITLE
WV-4121: Make sure that decoded json is array before union operation.

### DIFF
--- a/src/ResponseMerger/NuxtResponseMerger.php
+++ b/src/ResponseMerger/NuxtResponseMerger.php
@@ -29,7 +29,7 @@ class NuxtResponseMerger implements ResponseMergerInterface {
       throw new BadRequestHttpException("Invalid content type requested.");
     }
 
-    $data = json_decode($backendResponse->getBody()->__toString(), TRUE);
+    $data = (array) json_decode($backendResponse->getBody()->__toString(), TRUE);
     $data += [
       'messages' => [],
       'breadcrumbs' => [],


### PR DESCRIPTION
json_decode returns `NULL` if first parameter is badly formated json even if second parameter is set to true.

```
php > $bj="{'bar': 'baz'}";
php > var_dump(json_decode($bj, TRUE));
NULL  // <- should be [ ] at least. 
```

@fago Should catch that error?
```
if (!is_array($data)) {
  // log somewhere
}
```